### PR TITLE
Specify connection_name when connecting if present in behaviour config

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -40,6 +40,9 @@ function doConnect(behaviour, listener, callback) {
     savedConns[behaviour.reuse] = reuse;
   }
   var opts = {clientProperties: {product: behaviour.productName}};
+  if (behaviour.connectionName) {
+    opts.clientProperties.connection_name = behaviour.connectionName; //eslint-disable-line camelcase
+  }
   amqp.connect(amqpUrl, opts, function (connErr, newConnection) {
     if (connErr) {
       savedConns[behaviour.reuse] = null;


### PR DESCRIPTION
If behaviour.connectionName is set it will be added to the connection opts.

This enables us to specify the openshift pod name as connectionName and then ask the rabbit http api if the pod has a connection.